### PR TITLE
harden: add CSRF protection in auth.js...

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -3,6 +3,7 @@ const express = require('express')
 const morgan = require('morgan')
 const axios = require('axios')
 const cookieParser = require('cookie-parser')
+const csurf = require('csurf')
 const EventEmitter = require('node:events')
 
 const usersDb = require('./users/db')
@@ -18,7 +19,7 @@ const salt = randomString()
 const encrypt = ({ key, value }) =>
   crypto
     .createHmac('sha512', key + salt)
-    .update(`${value}`)
+    .update(String(value))
     .digest('hex')
     .slice(0, 7)
 
@@ -68,6 +69,7 @@ const getTokens = async code => {
 
 const app = express()
 app.use(cookieParser())
+app.use(csurf({ cookie: true }))
 app.use(
   morgan(':date[iso] :remote-addr :method :url HTTP/:http-version :status - :response-time ms')
 )

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@seald-io/nedb": "4.1.2",
     "axios": "1.19.0",
     "cookie-parser": "1.4.7",
+    "csurf": "1.11.0",
     "cron": "4.4.0",
     "envalid": "8.2.0",
     "express": "5.2.1",


### PR DESCRIPTION
## Summary
Harden input handling in `auth.js` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `javascript.express.security.audit.express-check-csurf-middleware-usage.express-check-csurf-middleware-usage` |
| **File** | `auth.js:69` |
| **Assessment** | Defensive hardening |

**Description**: A CSRF middleware was not detected in your express application. Ensure you are either using one such as `csurf` or `csrf` (see rule references) and/or you are properly doing CSRF validation in your routes with a token or cookies.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `auth.js`
- `package.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
