### PR TITLE
Run container as a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ WORKDIR /app
 RUN apk --no-cache add curl
 COPY --from=production-deps /app/node_modules /app/node_modules
 COPY --from=build-front /app/dist /app/static
+COPY --chown=node:node . .
+RUN mkdir -p /src/users/dbs && chown -R node:node /src
 VOLUME ["/src/users/dbs"]
-COPY . .
+USER node
 CMD node index.js


### PR DESCRIPTION
## Summary
- run the production image as the built-in `node` user
- make application files and the persistent database directory writable by that user

## Validation
- `git diff --check`

Closes the Trivy DS-0002 finding from job 98299659429.