### PR TITLE
ci: add gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,23 @@
+name: Gitleaks
+
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add a Gitleaks workflow for pull requests and pushes to `master` or `main`.
- Check out the full Git history and authenticate Gitleaks with the GitHub-provided token.

## Validation

- [x] `git diff --check`
- [ ] GitHub Actions run not available locally; it will run after this pull request is opened.
- [x] Tests not needed: workflow-only configuration change.

## Risks / rollout

- Adds a secret scan to pull request and primary-branch push CI.
- Roll back by reverting this commit.